### PR TITLE
Don't early leave on inaccessible files

### DIFF
--- a/src/directory/mod.rs
+++ b/src/directory/mod.rs
@@ -1,99 +1,68 @@
 use std::cmp::Ordering;
-use std::{error, fmt, fs, io};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::io::Write;
+use std::{fs, io};
 
 pub mod tree;
 pub mod print;
 
 use self::tree::{DirectoryNode, FileNode, FSNode};
 
-#[derive(Debug)]
-pub enum ReadDirError {
-    IoError {
-        err: io::Error,
-        path: PathBuf,
-    },
-}
-
-impl fmt::Display for ReadDirError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ReadDirError::IoError { ref err, ref path } => {
-                write!(f,
-                       "Error reading {:?}, caused by I/O error: {}",
-                       path,
-                       err)
-            }
-        }
-    }
-}
-
-impl error::Error for ReadDirError {
-    fn description(&self) -> &str {
-        match *self {
-            ReadDirError::IoError { ref err, .. } => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            ReadDirError::IoError { ref err, .. } => Some(err),
-        }
-    }
-}
-
-macro_rules! try_path {
-    ($expr:expr, $path:expr) => {
-        match $expr {
-            Ok(val) => val,
-            Err(err) => {
-                return Err(ReadDirError::IoError{err: err, path: $path.to_path_buf()});
-            }
-        }
-    }
-}
-
-pub fn read_recursive(path: &Path, ignore_dotfiles: bool, follow_symlinks: bool) -> Result<FSNode, ReadDirError> {
+pub fn read_recursive(path: &Path, ignore_dotfiles: bool, follow_symlinks: bool) -> FSNode {
     let name = path.file_name().unwrap_or(path.as_os_str()).to_string_lossy().to_string();
     let mut node = DirectoryNode::new(name);
 
-    for entry in try_path!(fs::read_dir(&path), path) {
-        let entry = try_path!(entry, path);
-        let path = entry.path();
-        let name = entry.file_name().to_string_lossy().to_string();
+    match fs::read_dir(&path) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(err) => {
+                        let _ = writeln!(io::stderr(), "Error reading {:?}, caused by I/O error: {}", path, err);
+                        continue;
+                    }
+                };
+                let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_string();
 
-        if ignore_dotfiles && name.starts_with('.') {
-            continue;
-        }
+                if ignore_dotfiles && name.starts_with('.') {
+                    continue;
+                }
 
-        let meta = if follow_symlinks {
-            // does traverse symlinks
-            try_path!(fs::metadata(&path), path)
-        } else {
-            // does not traverse symlinks, like fs::symlink_metadata
-            try_path!(entry.metadata(), &path)
-        };
+                let meta = match if follow_symlinks {
+                    // does traverse symlinks
+                    fs::metadata(&path)
+                } else {
+                    // does not traverse symlinks, like fs::symlink_metadata
+                    entry.metadata()
+                } {
+                    Ok(m) => m,
+                    Err(err) => {
+                        let _ = writeln!(io::stderr(), "Error reading {:?}, caused by I/O error: {}", path, err);
+                        continue;
+                    }
+                };
 
-        if meta.is_file() {
-            node.children.push(FSNode::File(FileNode {
-                name: name,
-                size: meta.len(),
-            }));
-            node.size += meta.len();
-        } else if meta.is_dir() {
-            match read_recursive(&path, ignore_dotfiles, follow_symlinks) {
-                Ok(dir) => {
+                if meta.is_file() {
+                    node.children.push(FSNode::File(FileNode {
+                        name: name,
+                        size: meta.len(),
+                    }));
+                    node.size += meta.len();
+                } else if meta.is_dir() {
+                    let dir = read_recursive(&path, ignore_dotfiles, follow_symlinks);
                     node.size += dir.size();
                     node.children.push(dir);
                 }
-                Err(err) => try_path!(writeln!(io::stderr(), "{}", err), Path::new("stderr")),
             }
+        }
+        Err(err) => {
+            let _ = writeln!(io::stderr(), "Error reading {:?}, caused by I/O error: {}", path, err);
         }
     }
 
     node.children.sort_by(biggest_size_first);
-    Ok(FSNode::Directory(node))
+    FSNode::Directory(node)
 }
 
 fn biggest_size_first(lhs: &FSNode, rhs: &FSNode) -> Ordering {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,5 @@ fn main() {
     let max_depth = i64::from_str(matches.value_of("max-depth").unwrap()).unwrap();
     let path = matches.value_of("DIRECTORY").unwrap().to_string();
 
-    match directory::read_recursive(std::path::Path::new(&path), ignore_dotfiles, follow_symlinks) {
-        Ok(ref tree) => directory::print::print_tree(tree, max_depth),
-        Err(e) => {
-            println!("{}", e);
-            std::process::exit(1);
-        }
-    }
+    directory::print::print_tree(&directory::read_recursive(std::path::Path::new(&path), ignore_dotfiles, follow_symlinks), max_depth);
 }


### PR DESCRIPTION
Example output (trimmed):

    d:\>T:\treesize-rs\target\debug\treesize.exe t:/
    Error reading "t:/System Volume Information", caused by I/O error: Access is denied. (os error 5)
    t:/                                            839.1  MB  (Σ)
    ├── -=- TEMP -=-                               261.9  MB  (Σ)
    ├── calibre-64bit-2.82.0.msi                   65.1   MB
    ├── LE40A856S1M                                56.8   MB  (Σ)
    ├── LE40A856S1MXXH                             56.8   MB  (Σ)
    ├── ed2ecdcf09650408af1250404dd493cd           30.1   MB  (Σ)
    ├── install-tl-windows.exe                     12.9   MB
    ├── BearLibTerminal                            11.0   MB  (Σ)
    ├── Kruger, Maria                              3.5    MB  (Σ)
    ├── BadEggsOnline2.swf                         3.2    MB
    ├── DSCN9603.JPG                               2.8    MB
    ├── fb4e2798-8398-49d3-9edc-9887f8407e5d.png   1.4    MB
    ├── cargo-install-update-TEST.tbz2             1.2    MB
    ├── a.exe                                      1.1    MB
    ├── image.png                                  744.0  KB
    ├── HS_Logo.jpg                                698.4  KB
    ├── image2.png                                 655.0  KB
    ├── Manifest Kaszystyczny - kaschism — v2.pdf  125.6  KB
    ├── logo.png                                   114.4  KB
    ├── widow.html                                 111.2  KB
    ├── latest.png                                 52.5   KB
    ├── mime.awk                                   45.2   KB
    ├── More description & data — kaschism.pdf     42.4   KB
    ├── Sernik Jaglany — kaschism A5.pdf           32.3   KB
    ├── Sernik Jaglany — kaschism.pdf              32.2   KB
    ├── mime - Copy.lst                            31.8   KB
    ├── mime.lst                                   31.8   KB