### PR TITLE
Add -s to select between human/SI/raw size format and reduce allocations

### DIFF
--- a/src/directory/print.rs
+++ b/src/directory/print.rs
@@ -102,17 +102,16 @@ impl fmt::Display for SizeFormatter {
         static HUMAN_PREFIX: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
         static SI_PREFIX: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB", "EB"];
 
-        let (power, prefix) = match self.0 {
-            SizeFormat::Human => (1024, HUMAN_PREFIX),
-            SizeFormat::Si => (1000, SI_PREFIX),
+        let (power, prefix, which) = match self.0 {
+            SizeFormat::Human => (1024, HUMAN_PREFIX, log2(self.1) / 10),
+            SizeFormat::Si => (1000, SI_PREFIX, log10(self.1) / 3),
             SizeFormat::Raw => return self.fmt_raw(f),
         };
 
-        if self.1 < power {
+        if which == 0 {
             return self.fmt_raw(f);
         }
 
-        let which = log2(self.1) / 10;
         let decimal = self.1 as f64 / (power as f64).powf(which as f64);
         write!(f, "{:.1}\t{}", decimal, prefix[which as usize])
     }
@@ -129,6 +128,16 @@ fn log2(mut x: u64) -> u64 {
 
     while (x >> 1) > 0 {
         x >>= 1;
+        n += 1;
+    }
+    n
+}
+
+fn log10(mut x: u64) -> u64 {
+    let mut n: u64 = 0;
+
+    while (x / 10) > 0 {
+        x /= 10;
         n += 1;
     }
     n

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,13 @@ fn main() {
                                      .default_value("5")
                                      .takes_value(true)
                                      .validator(validate_int))
+                            .arg(Arg::with_name("size-format")
+                                     .help("How to format node sizes: h/human – powers of 1024, H/si – powers of 1000, r/raw – no folding")
+                                     .short("s")
+                                     .default_value("human")
+                                     .takes_value(true)
+                                     .possible_values(directory::print::SizeFormat::VALUES)
+                                     .hide_possible_values(true))
                             .get_matches();
 
     let ignore_dotfiles = !matches.is_present("all");
@@ -48,6 +55,7 @@ fn main() {
     let one_file_system = matches.is_present("one-file-system");
     let max_depth = i64::from_str(matches.value_of("max-depth").unwrap()).unwrap();
     let max_entries = i64::from_str(matches.value_of("max-entries").unwrap()).unwrap();
+    let size_format = directory::print::SizeFormat::from_str(matches.value_of("size-format").unwrap()).unwrap();
     let path = matches.value_of("DIRECTORY").unwrap();
 
     directory::print::print_tree(&directory::read_recursive(std::path::Path::new(&path),
@@ -58,5 +66,5 @@ fn main() {
                                                             } else {
                                                                 directory::filesystem::FilesystemBehaviour::Traverse
                                                             }),
-                                 max_depth, max_entries);
+                                 max_depth, max_entries, size_format);
 }


### PR DESCRIPTION
I'm not sure if the numbers are accurate for SI because I don't get the math nor thought about it too hard but they looked fine on first glance?

Also closes #9 because this chooses the correct prefixes